### PR TITLE
Add better support for generic visitor details actions

### DIFF
--- a/app/styles/visitor.tss
+++ b/app/styles/visitor.tss
@@ -266,6 +266,25 @@
     font: {fontSize: '13sp', fontWeight: 'bold'},
 }
 
+".actionGenericTypeLabel": {
+    top: 0,
+    left: 6,
+    font: {fontSize: 13, fontWeight: 'bold'},
+    color: '#333333',
+    width: Ti.UI.SIZE,
+    height: Ti.UI.SIZE,
+}
+
+".actionGenericTypeLabel[platform=ios]": {
+    left: 10,
+}
+
+".actionGenericTypeLabel[platform=android]": {
+    left: '8dp',
+    font: {fontSize: '13sp', fontWeight: 'bold'},
+}
+
+
 ".actionDefaultUrlLabel": {
     color: '#808080',
     bottom: 5,


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/12284

This allows any action to control what to show in the mobile app for a specific action in an easy way directly in their plugin and the mobile app no longer needs to support each specific action. 

Tested on IOS12. Will test on Android before the next release, should work though.