### PR TITLE
Only allow light mode on iOS

### DIFF
--- a/tiapp.xml
+++ b/tiapp.xml
@@ -27,6 +27,10 @@
         <use-app-thinning>true</use-app-thinning>
         <plist>
             <dict>
+                <key>UIUserInterfaceStyle</key>
+                <string>Light</string>
+            </dict>
+            <dict>
                 <key>UIStatusBarStyle</key>
                 <string>UIStatusBarStyleLightContent</string>
             </dict>


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo-mobile-2/issues/5411