### PR TITLE
Update # FAQ Links

### DIFF
--- a/app/lib/Piwik/Network/HttpRequest.js
+++ b/app/lib/Piwik/Network/HttpRequest.js
@@ -399,7 +399,7 @@ HttpRequest.prototype.error = function (e) {
     
             case 'authentication needed':
 
-                message = 'Authentication is needed. Please read more here: https://matomo.org/faq/mobile-app/#faq_16336';
+                message = 'Authentication is needed. Please read more here: https://matomo.org/faq/mobile-app/faq_16336';
                 break;
     
             case 'host is unresolved':


### PR DESCRIPTION
A recent knowledge base update has changed how FAQ links work on matomo.org

Links with `#` in the link no longer work for guides or FAQs
