### PR TITLE
Prevent reports not being displayed when Multi Attribution is installed

### DIFF
--- a/app/models/piwikReports.js
+++ b/app/models/piwikReports.js
@@ -212,6 +212,7 @@ exports.definition = {
                 }
 
                 this.config.defaultParams.urls[0].idSites = siteModel.get('idsite');
+                this.config.defaultParams.urls[0].idSite = siteModel.get('idsite');
                 this.config.defaultParams.urls[1].idSite  = siteModel.get('idsite');
 
                 this.abortRunningRequests();


### PR DESCRIPTION
Specify idsite parameter in reportmetadata specificcally


