### PR TITLE
Set latest target SDK to 36

### DIFF
--- a/tiapp.xml
+++ b/tiapp.xml
@@ -34,7 +34,7 @@
                 </activity>
             </application>
             <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true" xlargeScreens="true"/>
-            <uses-sdk android:installLocation="preferExternal" android:minSdkVersion="32" />
+            <uses-sdk android:installLocation="preferExternal" android:minSdkVersion="32" android:targetSdkVersion="36" />
         </manifest>
     </android>
     <plugins>


### PR DESCRIPTION
We received email: App must target Android 16 (API level 36) or higher
To provide users with a safe and secure experience, Google Play requires all apps to meet target API level requirements.
From 31 Aug 2026, if your target API level is not within one year of the latest Android release, you won't be able to update your app.

As per https://github.com/tidev/titanium-sdk/issues/14353 it seems 16 is not yet the default target.
